### PR TITLE
feat: add new policy fields to put_policy

### DIFF
--- a/lib/qiniu/put_policy.ex
+++ b/lib/qiniu/put_policy.ex
@@ -9,6 +9,7 @@ defmodule Qiniu.PutPolicy do
   alias __MODULE__
 
   defstruct scope:                 nil,
+            is_prefixal_scope:     nil,
             deadline:              nil,
             insert_only:           nil,
             save_key:              nil,
@@ -23,13 +24,16 @@ defmodule Qiniu.PutPolicy do
             persistent_ops:        nil,
             persistent_notify_url: nil,
             persistent_pipeline:   nil,
+            fsize_min:             nil,
             fsize_limit:           nil,
             detect_mime:           nil,
             mime_limit:            nil,
-            checksum:              nil
+            checksum:              nil,
+            file_type:             nil
 
   @type t :: %Qiniu.PutPolicy{
             scope:                 String.t,
+            is_prefixal_scope:     integer | nil,
             deadline:              integer,
             insert_only:           integer | nil,
             save_key:              String.t | nil,
@@ -44,10 +48,12 @@ defmodule Qiniu.PutPolicy do
             persistent_ops:        String.t | nil,
             persistent_notify_url: String.t | nil,
             persistent_pipeline:   String.t | nil,
+            fsize_min:             integer | nil,
             fsize_limit:           integer | nil,
             detect_mime:           integer | nil,
             mime_limit:            String.t | nil,
-            checksum:              String.t | nil
+            checksum:              String.t | nil,
+            file_type:             integer | nil
             }
 
   @default_expires_in 3600

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], []},
+%{
+  "certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], []},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "excoveralls": {:hex, :excoveralls, "0.6.3", "894bf9254890a4aac1d1165da08145a72700ff42d8cb6ce8195a584cb2a4b374", [:mix], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
@@ -8,10 +9,11 @@
   "idna": {:hex, :idna, "5.0.1", "5aa8fdce3f876f49d90daa13f071155a7c3259d02f7847dadd164da4a877da2a", [:rebar3], [{:unicode_util_compat, "0.1.0", [hex: :unicode_util_compat, optional: false]}]},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
+  "meck": {:hex, :meck, "0.8.13", "ffedb39f99b0b99703b8601c6f17c7f76313ee12de6b646e671e3188401f7866", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mock": {:hex, :mock, "0.2.1", "bfdba786903e77f9c18772dee472d020ceb8ef000783e737725a4c8f54ad28ec", [:mix], [{:meck, "~> 0.8.2", [hex: :meck, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], []},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.1.0", "f554c539c826eac8bcf101d2dbcc4a798ba8a960a176ca58d0b2f225c265b174", [:rebar3], []}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.1.0", "f554c539c826eac8bcf101d2dbcc4a798ba8a960a176ca58d0b2f225c265b174", [:rebar3], []},
+}


### PR DESCRIPTION
See more: https://developer.qiniu.com/kodo/manual/1206/put-policy

```
"isPrefixalScope":     "<IsPrefixalScope          int>",
"fsizeMin":            "<FileSizeMin              int64>",
"fileType":           "<fileType                  int>"
```

|  Field   | Description  |
|  ----  | ----  |
| isPrefixalScope  | 若为 1，表示允许用户上传以 scope 的 keyPrefix 为前缀的文件。
| fsizeMin	| 定上传文件大小最小值，单位Byte。|
| fileType | 文件存储类型。0 为普通存储（默认），1 为低频存储。 |